### PR TITLE
allow for variable nwriters

### DIFF
--- a/askap/distributedimager/ContinuumWorker.cc
+++ b/askap/distributedimager/ContinuumWorker.cc
@@ -252,6 +252,7 @@ void ContinuumWorker::run(void)
   if (localSolver) {
     ASKAPLOG_INFO_STR(logger, "In local solver mode - reprocessing allocations)");
     itsAdvisor->updateComms();
+    itsComms.buildWriterIndex(itsComms.theWorkers());
     int myMinClient = itsComms.rank();
     int myMaxClient = itsComms.rank();
 
@@ -308,6 +309,7 @@ void ContinuumWorker::run(void)
       }
       initialiseBeamLog(nchanTotal);
       initialiseWeightsLog(nchanTotal);
+      itsComms.buildWriterIndex(itsComms.theWorkers());
 
   }
   ASKAPLOG_INFO_STR(logger, "Adding all missing parameters");
@@ -658,7 +660,7 @@ void ContinuumWorker::processChannels()
               itsPCFGridCube.reset(new CubeBuilder<casacore::Complex>(gridParset, this->nchanCube, f0, freqinc, pcfgrid_name, true));
               itsPSFGridCube.reset(new CubeBuilder<casacore::Complex>(gridParset, this->nchanCube, f0, freqinc, psfgrid_name, true));
           } else if ((itsGridType == "adios") && (itsParset.getString("imageaccess", "individual") == "collective")) {
-              size_t comm_index = itsComms.theWorkers();
+              size_t comm_index = itsComms.theWriters();
               itsVisGridCubeReal.reset(new CubeBuilder<casacore::Float>(itsComms, comm_index, gridParset, this->nchanCube, f0, freqinc, visgrid_name+".real", itsGridCoordUV));
               itsPCFGridCubeReal.reset(new CubeBuilder<casacore::Float>(itsComms, comm_index, gridParset, this->nchanCube, f0, freqinc, pcfgrid_name+".real", itsGridCoordUV));
               itsPSFGridCubeReal.reset(new CubeBuilder<casacore::Float>(itsComms, comm_index, gridParset, this->nchanCube, f0, freqinc, psfgrid_name+".real", itsGridCoordUV));

--- a/askap/distributedimager/CubeComms.cc
+++ b/askap/distributedimager/CubeComms.cc
@@ -86,15 +86,19 @@ size_t CubeComms::buildWriterIndex(size_t comm)
 {
 
     std::map<int, int>::iterator it = writerMap.begin();
-    std::vector<int> ranks(writerCount-1);
-    std::vector<int> comm_ranks(writerCount-1);
+    std::vector<int> ranks(writerMap.size());
+    std::vector<int> comm_ranks(writerMap.size());
     int wrt = 0;
     while (it != writerMap.end()) {
         ranks[wrt] = it->first;
         it++;
         wrt++;
     }
+    if (comm != 0){
     comm_ranks = translateRanks(ranks, comm);
+    } else {
+        comm_ranks = ranks;
+    }
     itsWriters = createComm(comm_ranks, comm);
     //ASKAPLOG_DEBUG_STR(logger, "Interwriter communicator index is " << itsComrades);
     return itsWriters;
@@ -113,6 +117,11 @@ std::vector<int> CubeComms::translateRanks(std::vector<int> ranks, size_t comm)
 
     MPI_Group_translate_ranks(world_group, n, ranks.data(), comm_group, ranksOut.data());
     return ranksOut;
+}
+#else
+std::vector<int> CubeComms::translateRanks(std::vector<int> ranks, size_t comm)
+{
+    ASKAPTHROW(AskapError, "CubeComms::translateRanks() cannot be used - configured without MPI");
 }
 #endif
 

--- a/askap/distributedimager/CubeComms.h
+++ b/askap/distributedimager/CubeComms.h
@@ -33,6 +33,9 @@
 
 #include <map>
 #include <list>
+#ifdef HAVE_MPI
+#include "mpi.h"
+#endif
 ///ASKAP includes ...
 #include <askap/askapparallel/AskapParallel.h>
 #include "askap/messages/IMessage.h"
@@ -98,7 +101,10 @@ class CubeComms: public askapparallel::AskapParallel {
         /// @brief its communicator for its fellow workers
         size_t buildCommIndex();
         /// @brief its communicator for its fellow writers
-        size_t buildWriterIndex();
+        size_t buildWriterIndex(size_t comm);
+
+        /// @brief translate vector of ranks from MPI_COMM_WORLD to specified comm
+        std::vector<int> translateRanks(std::vector<int> ranks, size_t comm);
       
         /// @brief sets the cubecreator to be the first writer
         void setSingleSink();

--- a/askap/distributedimager/CubeComms.h
+++ b/askap/distributedimager/CubeComms.h
@@ -101,7 +101,7 @@ class CubeComms: public askapparallel::AskapParallel {
         /// @brief its communicator for its fellow workers
         size_t buildCommIndex();
         /// @brief its communicator for its fellow writers
-        size_t buildWriterIndex(size_t comm);
+        size_t buildWriterIndex(size_t comm = 0);
 
         /// @brief translate vector of ranks from MPI_COMM_WORLD to specified comm
         std::vector<int> translateRanks(std::vector<int> ranks, size_t comm);


### PR DESCRIPTION
@pelahi 
I changed the buildWriterIndex function (It wasn't being used anywhere else, probably because it didn't work) to create a writer communicator from any communicator (not just MPI_COMM_WORLD). This fixed some of the shenanigans with the master rank causing deadlock if it's not involved in the creation of the new COMM. 

The most complicated part was that the writerMap's list of ranks was relative to WORLD and not the worker COMM. This needed to be translated via the MPI_Group_translate_ranks function. This part may be better off down in the depths of askapparallel, but I've put it here for now.

I've yet to fully compare the outputs, but this seems to work as expected. The run with 50 writers took 20s more than the one with 100 writers, but needs further testing.

Let me know what you think.